### PR TITLE
Handle receive-after-close from disBatch

### DIFF
--- a/kvscommon.py
+++ b/kvscommon.py
@@ -43,6 +43,8 @@ def AsciiLenFormat(n):
 if hasattr(socket, "MSG_WAITALL") and os.uname()[0] != 'Darwin':
     # MSG_WAITALL on OSX ends up blocking if the tcp buffer is not big enough for the entire message: don't use it
     def recvall(s, n):
+        if s is None:
+            raise socket.error('socket is None, cannot receive')
         if not n: return b''
         r = s.recv(n, socket.MSG_WAITALL)
         if len(r) < n: raise socket.error('Connection dropped')
@@ -50,6 +52,8 @@ if hasattr(socket, "MSG_WAITALL") and os.uname()[0] != 'Darwin':
 else:
     def recvall(s, n):
         '''Wrapper to deal with partial recvs when we know there are N bytes to be had.'''
+        if s is None:
+            raise socket.error('socket is None, cannot receive')
         d = b''
         while n:
             b = s.recv(n)


### PR DESCRIPTION
From flatironinstitute/disBatch#18, it appears that the kvs will sometimes be queried after it is closed depending on the timing of the SIGTERM signal.  That's fine; disBatch accounts for broken sockets at this stage by catching `socket.error`.  But receive-after-close currently triggers an `AttributeError` on `None` since the socket is `None` at this point.  This PR changes that behavior to a `socket.error` instead, so upstream handlers can meaningfully differentiate this scenario from other sources of `AttributeError`.

This is just one way to fix the issue; let me know what you think!

